### PR TITLE
Added usage tracking option for getData

### DIFF
--- a/spot.py
+++ b/spot.py
@@ -33,6 +33,7 @@ CONFIG = { 'caliquery': cali_query_path + '/cali-query'
          , 'jupyter_host': ''
          , 'jupyter_use_token': True
          , 'jupyter_token': ''
+         , 'usage_logging_dir': ''
          }
 
 
@@ -41,7 +42,6 @@ def _sub_call(cmd):
     return json.loads(subprocess.check_output(cmd).decode('utf-8'))
 
 def _cali_to_json(filepath):
-
     cali_json = _sub_call([CONFIG['caliquery'] , '-q', 'format json(object)', filepath])
     return cali_json
 
@@ -486,16 +486,17 @@ def memoryGraph(args):
 
 def update_usage_file(op):
     try:
-        pself = os.path.dirname(os.path.realpath(__file__))
-        usage_file_name = os.path.join(pself, 'usage.log')
+        usage_dir = CONFIG['usage_logging_dir']
+        if (usage_dir != ''):
+            usage_file_name = os.path.join(usage_dir, 'usage.log')
 
-        if os.path.exists(usage_file_name):
-            if os.access(usage_file_name, os.W_OK):
-                now = datetime.now()
-                date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
-                uname = getpass.getuser()
-                with open(usage_file_name, "a") as myfile:
-                    myfile.write(date_time + ' ' + uname + ' ' + op + '\n')
+            if os.path.exists(usage_file_name):
+                if os.access(usage_file_name, os.W_OK):
+                    now = datetime.now()
+                    date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
+                    uname = getpass.getuser()
+                    with open(usage_file_name, "a") as myfile:
+                        myfile.write(date_time + ' ' + uname + ' ' + op + '\n')
     except:
         pass
 

--- a/spot.py
+++ b/spot.py
@@ -485,16 +485,19 @@ def memoryGraph(args):
 
 
 def update_usage_file(op):
-    pself = os.path.dirname(os.path.realpath(__file__))
-    usage_file_name = os.path.join(pself, 'usage.log')
+    try:
+        pself = os.path.dirname(os.path.realpath(__file__))
+        usage_file_name = os.path.join(pself, 'usage.log')
 
-    if os.path.exists(usage_file_name):
-        if os.access(usage_file_name, os.W_OK):
-            now = datetime.now()
-            date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
-            uname = getpass.getuser()
-            with open(usage_file_name, "a") as myfile:
-                myfile.write(date_time + ' ' + uname + ' ' + op + '\n')
+        if os.path.exists(usage_file_name):
+            if os.access(usage_file_name, os.W_OK):
+                now = datetime.now()
+                date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
+                uname = getpass.getuser()
+                with open(usage_file_name, "a") as myfile:
+                    myfile.write(date_time + ' ' + uname + ' ' + op + '\n')
+    except:
+        pass
 
 def getData(args):
     update_usage_file("getData")

--- a/spot.py
+++ b/spot.py
@@ -484,7 +484,20 @@ def memoryGraph(args):
     json.dump(output, sys.stdout, indent=4)
 
 
+def update_usage_file(op):
+    pself = os.path.dirname(os.path.realpath(__file__))
+    usage_file_name = os.path.join(pself, 'usage.log')
+
+    if os.path.exists(usage_file_name):
+        if os.access(usage_file_name, os.W_OK):
+            now = datetime.now()
+            date_time = now.strftime("%m/%d/%Y, %H:%M:%S")
+            uname = getpass.getuser()
+            with open(usage_file_name, "a") as myfile:
+                myfile.write(date_time + ' ' + uname + ' ' + op + '\n')
+
 def getData(args):
+    update_usage_file("getData")
     dataSetKey = args.dataSetKey
     lastRead = args.lastRead or 0
     cachedRunCtimes = json.loads(args.cachedRunCtimes)

--- a/spot.py
+++ b/spot.py
@@ -33,7 +33,7 @@ CONFIG = { 'caliquery': cali_query_path + '/cali-query'
          , 'jupyter_host': ''
          , 'jupyter_use_token': True
          , 'jupyter_token': ''
-         , 'usage_logging_dir': ''
+         , 'usage_logging_dir': '/usr/gapps/spot/logs'
          }
 
 


### PR DESCRIPTION
This feature will check for a non-empty `usage_logging_dir` configuration string that may be set to a directory path for where the `usage.log` is to be kept.  If a file exists in this directory named `update.log` and the user running spot.py has write access to the file, a single line will be appended to this file using the following format:

"date, time, user name, getData"

This may be extended to track usage of other operations besides getData by adding the following line in the function for the operation as follows:

`update_usage_file("operation_name")`

This was tested with a browser pointing to the spot web page within the spot container and by attaching to the container with a terminal and manipulating the usage.log file as follows:

1. Run without modification (the default for `usage_logging_dir` is an empty string which disables logging).  (success case was that no usage information logged)
1. Set `usage_logging_dir: '/tmp/martymcf'` as the logging directory (but don't create it). (success case was that no usage information logged)
1. Create a directory `/tmp/martymcf` and run without usage.log file present (success case was that no usage information logged)
1. `touch /tmp/martymcf/usage.log; chmod 0400 /tmp/martymcf/usage.log` (success case was no usage information logged)
1. Run with /tmp/martymcf/usage.log file with 0402 permissions (success case was that usage data was appended to usage.log file)
